### PR TITLE
Add support for 32-bit CPUs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/biotinker/nlopt
+module github.com/go-nlopt/nlopt
 
 go 1.15

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/go-nlopt/nlopt
+module github.com/biotinker/nlopt
 
 go 1.15

--- a/nlopt_cfunc.go
+++ b/nlopt_cfunc.go
@@ -13,7 +13,7 @@ func nloptFunc(n uint, x *C.double, gradient *C.double, fData unsafe.Pointer) C.
 	var goGrad []float64
 	var cGrad []C.double
 	if gradient != nil {
-		cGrad = (*[((math.MaxInt32 - 1)/unsafe.Sizeof(x)]C.double)(unsafe.Pointer(gradient))[:n:n]
+		cGrad = (*[((math.MaxInt32 - 1)/unsafe.Sizeof(x))]C.double)(unsafe.Pointer(gradient))[:n:n]
 		goGrad = toGoArray(cGrad)
 	}
 	v := (C.double)(f(goX, goGrad))
@@ -28,20 +28,20 @@ func nloptFunc(n uint, x *C.double, gradient *C.double, fData unsafe.Pointer) C.
 //export nloptMfunc
 func nloptMfunc(m uint, result *C.double, n uint, x *C.double, gradient *C.double, fData unsafe.Pointer) {
 	f := getMfunc(uintptr(fData))
-	cX := (*[((math.MaxInt32 - 1)/unsafe.Sizeof(x)]C.double)(unsafe.Pointer(x))[:n:n]
+	cX := (*[((math.MaxInt32 - 1)/unsafe.Sizeof(x))]C.double)(unsafe.Pointer(x))[:n:n]
 	goX := toGoArray(cX)
 
 	var goGrad []float64
 	var cGrad []C.double
 	if gradient != nil {
-		cGrad = (*[((math.MaxInt32 - 1)/unsafe.Sizeof(x)]C.double)(unsafe.Pointer(gradient))[:n:n]
+		cGrad = (*[((math.MaxInt32 - 1)/unsafe.Sizeof(x))]C.double)(unsafe.Pointer(gradient))[:n:n]
 		goGrad = toGoArray(cGrad)
 	}
 
 	var goResult []float64
 	var cResult []C.double
 	if result != nil {
-		cResult = (*[((math.MaxInt32 - 1)/unsafe.Sizeof(x)]C.double)(unsafe.Pointer(result))[: m*n : m*n]
+		cResult = (*[((math.MaxInt32 - 1)/unsafe.Sizeof(x))]C.double)(unsafe.Pointer(result))[: m*n : m*n]
 		goResult = toGoArray(cResult)
 	}
 

--- a/nlopt_cfunc.go
+++ b/nlopt_cfunc.go
@@ -7,13 +7,13 @@ import "unsafe"
 //export nloptFunc
 func nloptFunc(n uint, x *C.double, gradient *C.double, fData unsafe.Pointer) C.double {
 	f := getFunc(uintptr(fData))
-	cX := (*[(math.MaxInt32 - 1)/unsafe.Sizeof(x)]C.double)(unsafe.Pointer(x))[:n:n]
+	cX := (*[(math.MaxInt32 - 1)/unsafe.Sizeof(*x)]C.double)(unsafe.Pointer(x))[:n:n]
 	goX := toGoArray(cX)
 
 	var goGrad []float64
 	var cGrad []C.double
 	if gradient != nil {
-		cGrad = (*[((math.MaxInt32 - 1)/unsafe.Sizeof(x))]C.double)(unsafe.Pointer(gradient))[:n:n]
+		cGrad = (*[((math.MaxInt32 - 1)/unsafe.Sizeof(*x))]C.double)(unsafe.Pointer(gradient))[:n:n]
 		goGrad = toGoArray(cGrad)
 	}
 	v := (C.double)(f(goX, goGrad))
@@ -28,20 +28,20 @@ func nloptFunc(n uint, x *C.double, gradient *C.double, fData unsafe.Pointer) C.
 //export nloptMfunc
 func nloptMfunc(m uint, result *C.double, n uint, x *C.double, gradient *C.double, fData unsafe.Pointer) {
 	f := getMfunc(uintptr(fData))
-	cX := (*[((math.MaxInt32 - 1)/unsafe.Sizeof(x))]C.double)(unsafe.Pointer(x))[:n:n]
+	cX := (*[((math.MaxInt32 - 1)/unsafe.Sizeof(*x))]C.double)(unsafe.Pointer(x))[:n:n]
 	goX := toGoArray(cX)
 
 	var goGrad []float64
 	var cGrad []C.double
 	if gradient != nil {
-		cGrad = (*[((math.MaxInt32 - 1)/unsafe.Sizeof(x))]C.double)(unsafe.Pointer(gradient))[:n:n]
+		cGrad = (*[((math.MaxInt32 - 1)/unsafe.Sizeof(*x))]C.double)(unsafe.Pointer(gradient))[:n:n]
 		goGrad = toGoArray(cGrad)
 	}
 
 	var goResult []float64
 	var cResult []C.double
 	if result != nil {
-		cResult = (*[((math.MaxInt32 - 1)/unsafe.Sizeof(x))]C.double)(unsafe.Pointer(result))[: m*n : m*n]
+		cResult = (*[((math.MaxInt32 - 1)/unsafe.Sizeof(*x))]C.double)(unsafe.Pointer(result))[: m*n : m*n]
 		goResult = toGoArray(cResult)
 	}
 

--- a/nlopt_cfunc.go
+++ b/nlopt_cfunc.go
@@ -1,18 +1,19 @@
 package nlopt
 
 import "C"
+import "math"
 import "unsafe"
 
 //export nloptFunc
 func nloptFunc(n uint, x *C.double, gradient *C.double, fData unsafe.Pointer) C.double {
 	f := getFunc(uintptr(fData))
-	cX := (*[(1 << 29) - 1]C.double)(unsafe.Pointer(x))[:n:n]
+	cX := (*[(math.MaxInt32 - 1)/unsafe.Sizeof(x)]C.double)(unsafe.Pointer(x))[:n:n]
 	goX := toGoArray(cX)
 
 	var goGrad []float64
 	var cGrad []C.double
 	if gradient != nil {
-		cGrad = (*[(1 << 29) - 1]C.double)(unsafe.Pointer(gradient))[:n:n]
+		cGrad = (*[((math.MaxInt32 - 1)/unsafe.Sizeof(x)]C.double)(unsafe.Pointer(gradient))[:n:n]
 		goGrad = toGoArray(cGrad)
 	}
 	v := (C.double)(f(goX, goGrad))
@@ -27,20 +28,20 @@ func nloptFunc(n uint, x *C.double, gradient *C.double, fData unsafe.Pointer) C.
 //export nloptMfunc
 func nloptMfunc(m uint, result *C.double, n uint, x *C.double, gradient *C.double, fData unsafe.Pointer) {
 	f := getMfunc(uintptr(fData))
-	cX := (*[(1 << 29) - 1]C.double)(unsafe.Pointer(x))[:n:n]
+	cX := (*[((math.MaxInt32 - 1)/unsafe.Sizeof(x)]C.double)(unsafe.Pointer(x))[:n:n]
 	goX := toGoArray(cX)
 
 	var goGrad []float64
 	var cGrad []C.double
 	if gradient != nil {
-		cGrad = (*[(1 << 29) - 1]C.double)(unsafe.Pointer(gradient))[:n:n]
+		cGrad = (*[((math.MaxInt32 - 1)/unsafe.Sizeof(x)]C.double)(unsafe.Pointer(gradient))[:n:n]
 		goGrad = toGoArray(cGrad)
 	}
 
 	var goResult []float64
 	var cResult []C.double
 	if result != nil {
-		cResult = (*[(1 << 29) - 1]C.double)(unsafe.Pointer(result))[: m*n : m*n]
+		cResult = (*[((math.MaxInt32 - 1)/unsafe.Sizeof(x)]C.double)(unsafe.Pointer(result))[: m*n : m*n]
 		goResult = toGoArray(cResult)
 	}
 

--- a/nlopt_cfunc.go
+++ b/nlopt_cfunc.go
@@ -6,13 +6,13 @@ import "unsafe"
 //export nloptFunc
 func nloptFunc(n uint, x *C.double, gradient *C.double, fData unsafe.Pointer) C.double {
 	f := getFunc(uintptr(fData))
-	cX := (*[1 << 30]C.double)(unsafe.Pointer(x))[:n:n]
+	cX := (*[(1 << 29) - 1]C.double)(unsafe.Pointer(x))[:n:n]
 	goX := toGoArray(cX)
 
 	var goGrad []float64
 	var cGrad []C.double
 	if gradient != nil {
-		cGrad = (*[1 << 30]C.double)(unsafe.Pointer(gradient))[:n:n]
+		cGrad = (*[(1 << 29) - 1]C.double)(unsafe.Pointer(gradient))[:n:n]
 		goGrad = toGoArray(cGrad)
 	}
 	v := (C.double)(f(goX, goGrad))
@@ -27,20 +27,20 @@ func nloptFunc(n uint, x *C.double, gradient *C.double, fData unsafe.Pointer) C.
 //export nloptMfunc
 func nloptMfunc(m uint, result *C.double, n uint, x *C.double, gradient *C.double, fData unsafe.Pointer) {
 	f := getMfunc(uintptr(fData))
-	cX := (*[1 << 30]C.double)(unsafe.Pointer(x))[:n:n]
+	cX := (*[(1 << 29) - 1]C.double)(unsafe.Pointer(x))[:n:n]
 	goX := toGoArray(cX)
 
 	var goGrad []float64
 	var cGrad []C.double
 	if gradient != nil {
-		cGrad = (*[1 << 30]C.double)(unsafe.Pointer(gradient))[:n:n]
+		cGrad = (*[(1 << 29) - 1]C.double)(unsafe.Pointer(gradient))[:n:n]
 		goGrad = toGoArray(cGrad)
 	}
 
 	var goResult []float64
 	var cResult []C.double
 	if result != nil {
-		cResult = (*[1 << 30]C.double)(unsafe.Pointer(result))[: m*n : m*n]
+		cResult = (*[(1 << 29) - 1]C.double)(unsafe.Pointer(result))[: m*n : m*n]
 		goResult = toGoArray(cResult)
 	}
 


### PR DESCRIPTION
*[1 << 30]C.double is too large for this library to be usable on 32-bit CPUs such as Raspberry Pis. This sets affected arrays to the maximum supported size for 32bits.