### PR TITLE
Use safe primitives for C function pointers

### DIFF
--- a/cfunc_reg.go
+++ b/cfunc_reg.go
@@ -7,41 +7,41 @@ import (
 var (
 	funcMutex sync.Mutex
 
-	funcMap = make(map[uintptr]interface{})
-	funcPtr uintptr
+	funcMap = make(map[*uint8]interface{})
 )
 
-func makeFuncPtr(f Func) uintptr {
+func makeFuncPtr(f Func) *uint8 {
 	return _setFuncMapEntry(f)
 }
 
-func makeMfuncPtr(f Mfunc) uintptr {
+func makeMfuncPtr(f Mfunc) *uint8 {
 	return _setFuncMapEntry(f)
 }
 
-func _setFuncMapEntry(f interface{}) uintptr {
+func _setFuncMapEntry(f interface{}) *uint8 {
 	funcMutex.Lock()
 	defer funcMutex.Unlock()
-	funcPtr++
-	funcMap[funcPtr] = f
-	return funcPtr
+	var funcPtr uint8
+	funcMap[&funcPtr] = f
+
+	return &funcPtr
 }
 
-func getFunc(ptr uintptr) Func {
+func getFunc(ptr *uint8) Func {
 	return _getFuncMapEntry(ptr).(Func)
 }
 
-func getMfunc(ptr uintptr) Mfunc {
+func getMfunc(ptr *uint8) Mfunc {
 	return _getFuncMapEntry(ptr).(Mfunc)
 }
 
-func _getFuncMapEntry(ptr uintptr) interface{} {
+func _getFuncMapEntry(ptr *uint8) interface{} {
 	funcMutex.Lock()
 	defer funcMutex.Unlock()
 	return funcMap[ptr]
 }
 
-func freeFuncPtr(ptr uintptr) {
+func freeFuncPtr(ptr *uint8) {
 	funcMutex.Lock()
 	defer funcMutex.Unlock()
 

--- a/nlopt.go
+++ b/nlopt.go
@@ -233,7 +233,7 @@ type NLopt struct {
 	dim  uint
 
 	mutex      sync.Mutex
-	funcs      []uintptr
+	funcs      []*uint8
 	lastStatus string
 }
 
@@ -256,7 +256,7 @@ func NewNLopt(algorithm int, n uint) (*NLopt, error) {
 	}, nil
 }
 
-func (n *NLopt) addFunc(f Func) uintptr {
+func (n *NLopt) addFunc(f Func) *uint8 {
 	n.mutex.Lock()
 	defer n.mutex.Unlock()
 
@@ -265,7 +265,7 @@ func (n *NLopt) addFunc(f Func) uintptr {
 	return ptr
 }
 
-func (n *NLopt) addMfunc(f Mfunc) uintptr {
+func (n *NLopt) addMfunc(f Mfunc) *uint8 {
 	n.mutex.Lock()
 	defer n.mutex.Unlock()
 
@@ -297,7 +297,7 @@ func (n *NLopt) Destroy() {
 	for _, ptr := range n.funcs {
 		freeFuncPtr(ptr)
 	}
-	n.funcs = []uintptr{}
+	n.funcs = []*uint8{}
 }
 
 // Copy makes an independent copy of an object

--- a/nlopt_cfunc.go
+++ b/nlopt_cfunc.go
@@ -1,19 +1,21 @@
 package nlopt
 
 import "C"
-import "math"
-import "unsafe"
+import (
+	"math"
+	"unsafe"
+)
 
 //export nloptFunc
 func nloptFunc(n uint, x *C.double, gradient *C.double, fData unsafe.Pointer) C.double {
-	f := getFunc(uintptr(fData))
-	cX := (*[(math.MaxInt32 - 1)/unsafe.Sizeof(*x)]C.double)(unsafe.Pointer(x))[:n:n]
+	f := getFunc((*uint8)(fData))
+	cX := (*[(math.MaxInt32 - 1) / unsafe.Sizeof(*x)]C.double)(unsafe.Pointer(x))[:n:n]
 	goX := toGoArray(cX)
 
 	var goGrad []float64
 	var cGrad []C.double
 	if gradient != nil {
-		cGrad = (*[((math.MaxInt32 - 1)/unsafe.Sizeof(*x))]C.double)(unsafe.Pointer(gradient))[:n:n]
+		cGrad = (*[((math.MaxInt32 - 1) / unsafe.Sizeof(*x))]C.double)(unsafe.Pointer(gradient))[:n:n]
 		goGrad = toGoArray(cGrad)
 	}
 	v := (C.double)(f(goX, goGrad))
@@ -27,21 +29,21 @@ func nloptFunc(n uint, x *C.double, gradient *C.double, fData unsafe.Pointer) C.
 
 //export nloptMfunc
 func nloptMfunc(m uint, result *C.double, n uint, x *C.double, gradient *C.double, fData unsafe.Pointer) {
-	f := getMfunc(uintptr(fData))
-	cX := (*[((math.MaxInt32 - 1)/unsafe.Sizeof(*x))]C.double)(unsafe.Pointer(x))[:n:n]
+	f := getMfunc((*uint8)(fData))
+	cX := (*[((math.MaxInt32 - 1) / unsafe.Sizeof(*x))]C.double)(unsafe.Pointer(x))[:n:n]
 	goX := toGoArray(cX)
 
 	var goGrad []float64
 	var cGrad []C.double
 	if gradient != nil {
-		cGrad = (*[((math.MaxInt32 - 1)/unsafe.Sizeof(*x))]C.double)(unsafe.Pointer(gradient))[:n:n]
+		cGrad = (*[((math.MaxInt32 - 1) / unsafe.Sizeof(*x))]C.double)(unsafe.Pointer(gradient))[:n:n]
 		goGrad = toGoArray(cGrad)
 	}
 
 	var goResult []float64
 	var cResult []C.double
 	if result != nil {
-		cResult = (*[((math.MaxInt32 - 1)/unsafe.Sizeof(*x))]C.double)(unsafe.Pointer(result))[: m*n : m*n]
+		cResult = (*[((math.MaxInt32 - 1) / unsafe.Sizeof(*x))]C.double)(unsafe.Pointer(result))[: m*n : m*n]
 		goResult = toGoArray(cResult)
 	}
 


### PR DESCRIPTION
This fixes:
```
fatal error: checkptr: pointer arithmetic computed bad pointer value

goroutine 20 [running]:
runtime.throw(0x10374503a, 0x37)
	/usr/local/go/src/runtime/panic.go:1117 +0x54 fp=0xc0004b9880 sp=0xc0004b9850 pc=0x102d85fa4
runtime.checkptrArithmetic(0x1, 0x0, 0x0, 0x0)
	/usr/local/go/src/runtime/checkptr.go:26 +0xd4 fp=0xc0004b98b0 sp=0xc0004b9880 pc=0x102d57974
github.com/go-nlopt/nlopt.(*NLopt).SetMinObjective.func1.1(0xc000515280, 0x1, 0x1)
	/Users/eric/go/pkg/mod/github.com/go-nlopt/nlopt@v0.0.0-20210301200439-7a900255de5c/nlopt.go:335 +0x74 fp=0xc0004b9900 sp=0xc0004b98b0 pc=0x1036c20f4
```