### PR TITLE
prefer cgo pkg-config for nlopt on non-windows systems

### DIFF
--- a/nlopt.go
+++ b/nlopt.go
@@ -2,7 +2,9 @@ package nlopt
 
 /*
 #cgo CFLAGS: -Os
-#cgo LDFLAGS: -lnlopt -lm
+#cgo windows LDFLAGS: -lnlopt -lm
+#cgo !windows LDFLAGS: -lm
+#cgo !windows pkg-config: nlopt
 #include "nlopt.h"
 #include <stdlib.h>
 


### PR DESCRIPTION
This will make non-standard installations easier to use.